### PR TITLE
Website restructure: new homepage + market/offer-bot pages, landing FOUC fix & code-split

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,23 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1" />
 
-    <title>ResidenceHive | AI-Powered Lead Engagement for Real Estate</title>
-    <meta name="description" content="ResidenceHive is the first-response layer for real estate. Transform generic lead responses into curated, compliant buyer engagement that converts." />
+    <title>ResidenceHive | AI-Powered Workflows for Real Estate Agents</title>
+    <meta name="description" content="From first lead response to draft-ready offers — built around how agents actually work in each market." />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://residencehive.com/" />
 
     <!-- Open Graph -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://residencehive.com/" />
-    <meta property="og:title" content="ResidenceHive | AI-Powered Lead Engagement for Real Estate" />
-    <meta property="og:description" content="Transform generic lead responses into curated, compliant buyer engagement that converts. The first-response layer for real estate." />
+    <meta property="og:title" content="ResidenceHive | AI-Powered Workflows for Real Estate Agents" />
+    <meta property="og:description" content="From first lead response to draft-ready offers — built around how agents actually work in each market." />
     <meta property="og:image" content="https://residencehive.com/og-image.svg" />
     <meta property="og:site_name" content="ResidenceHive" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="ResidenceHive | AI-Powered Lead Engagement for Real Estate" />
-    <meta name="twitter:description" content="Transform generic lead responses into curated, compliant buyer engagement that converts. The first-response layer for real estate." />
+    <meta name="twitter:title" content="ResidenceHive | AI-Powered Workflows for Real Estate Agents" />
+    <meta name="twitter:description" content="From first lead response to draft-ready offers — built around how agents actually work in each market." />
     <meta name="twitter:image" content="https://residencehive.com/og-image.svg" />
 
     <!-- Favicon -->

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -53,6 +53,7 @@
         "react": "^18.3.1",
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^3.0.0",
         "react-hook-form": "^7.55.0",
         "react-markdown": "^10.1.0",
         "react-resizable-panels": "^2.1.7",
@@ -4610,6 +4611,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -6409,6 +6419,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.64.0",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.64.0.tgz",
@@ -6920,6 +6950,12 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.55.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^2.1.7",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -16,9 +16,10 @@ const LANDING_PAGE_CONTENT = `
 <header>
   <nav>
     <a href="/"><strong>ResidenceHive</strong></a>
+    <a href="/massachusetts">Massachusetts</a>
+    <a href="/ontario">Ontario</a>
+    <a href="/offer-bot">Offer Bot</a>
     <a href="#how-it-works">How It Works</a>
-    <a href="#features">Features</a>
-    <a href="#why-us">Why Us</a>
     <a href="/sign-in">Sign In</a>
     <a href="/sign-up">Request Demo</a>
   </nav>
@@ -26,29 +27,26 @@ const LANDING_PAGE_CONTENT = `
 
 <main>
   <section id="hero">
-    <p>Now in Private Pilot</p>
-    <h1>The first-response layer for real estate</h1>
-    <p>Transform generic lead responses into curated, compliant buyer engagement that converts.</p>
-    <p><strong>78% of real estate leads never receive a personalized response.</strong></p>
+    <p>Now in Private Pilot — Massachusetts &amp; Ontario</p>
+    <h1>Which one would your buyer respond to?</h1>
+    <p>AI handles the first response and offer prep. Your agents handle the relationship.</p>
+    <p>Cost per lead: $100–225+. ~15 min saved per listing.</p>
   </section>
 
   <section id="problem">
-    <h2>The problem with lead response today</h2>
-    <p>Real estate leads are expensive, but most brokerages struggle to respond effectively.</p>
+    <h2>Your agent should be showing homes — instead they're stuck</h2>
 
-    <h3>Expensive, Ignored</h3>
-    <p>Brokerages pay $100-225+ per lead. Most never get a meaningful response.</p>
+    <h3>Lead Engagement — $100–225+ per lead, gone</h3>
+    <p>Showing homes, building relationships, and converting is the job. Instead agents copy-paste 30 listings into an email no one reads. 78% of leads ghost before your agent even picks up the phone — a generic listing dump that looks like spam, zero intent captured, and no follow-up.</p>
+    <p>ResidenceHive handles the first response. Your agent steps in when the buyer is ready to talk.</p>
 
-    <h3>Generic Replies</h3>
-    <p>Buyers get 30-40 unranked listings with no explanation or trade-offs. It looks like spam.</p>
-
-    <h3>Lost Intent</h3>
-    <p>Buyer questions reveal timeline, budget, must-haves. Traditional CRMs capture none of it.</p>
+    <h3>Offer Prep — ~15 min per offer, wasted</h3>
+    <p>Winning deals means submitting on tight deadlines. Instead agents retype property details into blank forms at midnight — multiplied by 3 competing offers on a Friday night. Manual data entry, a missing clause that kills the deal, agent time burned on paperwork instead of negotiation.</p>
+    <p>ResidenceHive preps the draft. Your agent reviews, edits, and sends — in minutes, not hours.</p>
   </section>
 
   <section id="features">
     <h2>A smarter first response</h2>
-    <p>ResidenceHive transforms how brokerages engage leads from the first touchpoint.</p>
 
     <h3>Curated Top-5</h3>
     <p>Instead of 40 listings, buyers get 5 ranked picks with clear explanations of why each fits.</p>
@@ -65,22 +63,29 @@ const LANDING_PAGE_CONTENT = `
 
   <section id="how-it-works">
     <h2>How it works</h2>
-    <p>From lead to qualified buyer in five seamless steps.</p>
 
-    <h3>Step 1: Lead Arrives</h3>
-    <p>From website, Zillow, Realtor.com, or referral.</p>
+    <h3>Lead Engagement</h3>
+    <p>Turn raw leads into qualified buyers with AI-powered first response.</p>
+    <p>Lead arrives from your website, Zillow, Realtor.com, or a referral. AI extracts budget, timeline, must-haves, and dealbreakers. A curated Top-5 report is generated with personalized explanations. The chatbot answers buyer questions within compliance guardrails. Your agent acts on a qualified lead with full context — ready for action.</p>
 
-    <h3>Step 2: AI Analyzes</h3>
-    <p>Extracts budget, timeline, must-haves, dealbreakers.</p>
+    <h3>Offer Bot</h3>
+    <p>Go from a listing address to a draft-ready offer package in minutes.</p>
+    <p>The agent sends deal details in natural language via WhatsApp — no forms. The system extracts price, conditions, dates, parties, and clauses, then flags any missing fields. A pre-filled draft package is generated for agent review. Nothing goes out without agent approval.</p>
+  </section>
 
-    <h3>Step 3: Report Generated</h3>
-    <p>Curated Top-5 with personalized explanations.</p>
+  <section id="channels">
+    <h2>Works on any phone — WhatsApp, iMessage &amp; SMS</h2>
+    <p>No app to download. Works on any phone. One number for everything.</p>
+  </section>
 
-    <h3>Step 4: Buyer Engages</h3>
-    <p>Chatbot answers questions within compliance guardrails.</p>
+  <section id="markets">
+    <h2>Built for your market</h2>
 
-    <h3>Step 5: Agent Acts</h3>
-    <p>Receive qualified lead with full context - ready for action.</p>
+    <h3>Massachusetts</h3>
+    <p>Purpose-built for MA agents. MLS PIN data, local compliance guardrails, and buyer engagement workflows designed for how Massachusetts transactions actually work — lead intake and buyer qualification, a compliance-first chatbot with Fair Housing guardrails, and MLS-contextual buyer reports.</p>
+
+    <h3>Ontario</h3>
+    <p>Built around Ontario agent workflows. From buyer engagement to draft offer packages — localized for how Ontario deals move, including lead engagement and buyer intake, listing-aware offer preparation, and draft OREA form generation for agent review.</p>
   </section>
 
   <section id="why-us">
@@ -97,32 +102,32 @@ const LANDING_PAGE_CONTENT = `
         <tr><td>Automatic intent capture</td><td>No</td><td>Yes</td></tr>
         <tr><td>Compliance guardrails</td><td>No</td><td>Yes</td></tr>
         <tr><td>Risk detection and escalation</td><td>No</td><td>Yes</td></tr>
+        <tr><td>Market-specific form generation</td><td>No</td><td>Yes</td></tr>
       </tbody>
     </table>
   </section>
 
   <section id="social-proof">
     <h2>Results</h2>
-    <p><strong>~15 min</strong> saved per listing</p>
-    <p><strong>$100+</strong> lead cost protected</p>
-    <p><strong>Toronto</strong> pilot market</p>
-    <blockquote>"This saves me ~15 minutes per listing." — Agent (demo)</blockquote>
+    <p><strong>2 Markets</strong> active pilots</p>
+    <p><strong>MLS PIN</strong> &amp; listing data access</p>
+    <p><strong>6-Tier</strong> compliance framework</p>
+    <blockquote>"This saves me 15 minutes per listing and catches things I'd miss." — Pilot agent</blockquote>
   </section>
 
   <section id="cta">
-    <h2>Ready to transform your lead response?</h2>
-    <p>Join the private pilot and see ResidenceHive in action.</p>
-    <a href="/sign-up">Request Demo</a>
-    <p><strong>$100/seat/month | No long-term contracts</strong></p>
+    <h2>Ready to transform your workflow?</h2>
+    <p>Join the private pilot — 60 days free, no contracts.</p>
+    <a href="/sign-up">Request Demo — Pilots are free for 60 days</a>
   </section>
 </main>
 
 <footer>
   <p><strong>ResidenceHive</strong></p>
   <nav>
-    <a href="mailto:info@residencehive.com">Contact</a>
+    <a href="mailto:hello@residencehive.com">Contact</a>
     <a href="/privacy">Privacy Policy</a>
-    <a href="/terms">Terms</a>
+    <a href="/compliance">Compliance</a>
   </nav>
   <p>&copy; ResidenceHive 2026</p>
 </footer>
@@ -133,10 +138,18 @@ let prerenderedIndexHtml = null;
 function getPrerenderedHtml() {
   if (!prerenderedIndexHtml) {
     const indexHtml = fs.readFileSync(path.join(__dirname, 'dist', 'index.html'), 'utf-8');
-    prerenderedIndexHtml = indexHtml.replace(
-      '<div id="root"></div>',
-      `<div id="root">${LANDING_PAGE_CONTENT}</div>`
-    );
+    // The SEO content below is unstyled HTML meant for crawlers/AI tools. Real
+    // browsers must NOT see it: until the React bundle loads and replaces #root,
+    // hide the pre-render visually so users don't get a flash of unstyled content
+    // (FOUC). Text-based crawlers read the markup regardless of this CSS.
+    const hidePrerenderStyle =
+      '<style>#root > header,#root > main,#root > footer{display:none!important}</style>';
+    prerenderedIndexHtml = indexHtml
+      .replace('</head>', `${hidePrerenderStyle}</head>`)
+      .replace(
+        '<div id="root"></div>',
+        `<div id="root">${LANDING_PAGE_CONTENT}</div>`
+      );
   }
   return prerenderedIndexHtml;
 }

--- a/frontend/src/AppRoot.tsx
+++ b/frontend/src/AppRoot.tsx
@@ -1,0 +1,29 @@
+import App from "./App";
+import { ClerkProvider } from "@clerk/clerk-react";
+
+const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
+
+if (!clerkPubKey) {
+  // eslint-disable-next-line no-console
+  console.warn("VITE_CLERK_PUBLISHABLE_KEY is not set. Clerk auth will be disabled.");
+}
+
+// Wraps the full app (and all its heavy page/chart/Clerk dependencies) so it can
+// be code-split out of the entry bundle. The public marketing pages never import
+// this, keeping their payload tiny.
+export default function AppRoot() {
+  if (!clerkPubKey) {
+    return <App />;
+  }
+
+  return (
+    <ClerkProvider
+      publishableKey={clerkPubKey}
+      signInUrl="/sign-in"
+      signUpUrl="/sign-up"
+      afterSignOutUrl="/"
+    >
+      <App />
+    </ClerkProvider>
+  );
+}

--- a/frontend/src/components/SEO.tsx
+++ b/frontend/src/components/SEO.tsx
@@ -1,0 +1,22 @@
+import { Helmet } from "react-helmet-async";
+
+interface SEOProps {
+  title: string;
+  description: string;
+  canonical?: string;
+}
+
+export function SEO({ title, description, canonical }: SEOProps) {
+  return (
+    <Helmet>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      {canonical && <link rel="canonical" href={canonical} />}
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:site_name" content="ResidenceHive" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </Helmet>
+  );
+}

--- a/frontend/src/components/landing/CTASection.tsx
+++ b/frontend/src/components/landing/CTASection.tsx
@@ -1,38 +1,22 @@
-import { useState } from "react";
-import { ArrowRight } from "lucide-react";
+import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
-import { DemoRequestModal } from "./DemoRequestModal";
 
 export function CTASection() {
-  const [demoModalOpen, setDemoModalOpen] = useState(false);
-
   return (
-    <section className="py-16 sm:py-24 bg-teal-600">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-        <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
-          Ready to transform your lead response?
+    <section className="py-20 bg-gradient-to-b from-white to-[#f0fdfa]">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+          Ready to transform your workflow?
         </h2>
-        <p className="text-xl text-teal-100 mb-8 max-w-2xl mx-auto">
-          Join the private pilot and see ResidenceHive in action.
+        <p className="text-[#6b7280] text-lg mb-8">
+          Join the private pilot — 60 days free, no contracts.
         </p>
-
-        <Button
-          size="lg"
-          variant="secondary"
-          className="text-lg px-8 py-6 h-auto bg-white text-teal-600 hover:bg-teal-50"
-          onClick={() => setDemoModalOpen(true)}
-        >
-          Request Demo
-          <ArrowRight className="ml-2 h-5 w-5" />
-        </Button>
-
-        <p className="mt-6 text-teal-200 text-sm">
-          $100/seat/month | No long-term contracts
-        </p>
+        <Link href="/sign-up">
+          <Button size="lg" className="bg-teal-600 hover:bg-teal-700 text-white shadow-lg px-8 py-3 text-base">
+            Request Demo — Pilots are free for 60 days
+          </Button>
+        </Link>
       </div>
-
-      {/* Demo Request Modal */}
-      <DemoRequestModal open={demoModalOpen} onOpenChange={setDemoModalOpen} />
     </section>
   );
 }

--- a/frontend/src/components/landing/ChannelsSection.tsx
+++ b/frontend/src/components/landing/ChannelsSection.tsx
@@ -1,0 +1,98 @@
+import { Smartphone, CheckCircle, Link2 } from "lucide-react";
+
+function ChatMockup({
+  platform,
+  platformColor,
+  platformIcon,
+  agentMsg,
+  botMsg,
+  footerText,
+}: {
+  platform: string;
+  platformColor: string;
+  platformIcon: string;
+  agentMsg: string;
+  botMsg: string;
+  footerText: string;
+}) {
+  return (
+    <div className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] overflow-hidden">
+      <div className="p-7 sm:p-8">
+        <div className="flex items-center gap-2 mb-4">
+          <span className="text-2xl">{platformIcon}</span>
+          <span className="font-semibold text-[#111827]">{platform}</span>
+        </div>
+        <div className="bg-[#f9fafb] rounded-xl p-4 space-y-3 min-h-[180px]">
+          {/* Agent bubble */}
+          <div className="flex justify-end">
+            <div className="bg-teal-600 text-white text-sm rounded-2xl rounded-br-sm px-4 py-2.5 max-w-[85%]">
+              {agentMsg}
+            </div>
+          </div>
+          {/* Bot bubble */}
+          <div className="flex justify-start">
+            <div className="bg-white border border-[#e5e7eb] text-[#111827] text-sm rounded-2xl rounded-bl-sm px-4 py-2.5 max-w-[85%]">
+              {botMsg}
+            </div>
+          </div>
+          {/* Typing indicator */}
+          <div className="flex justify-start">
+            <div className="bg-white border border-[#e5e7eb] rounded-2xl rounded-bl-sm px-4 py-2.5">
+              <div className="flex gap-1">
+                <span className="w-2 h-2 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "0ms" }} />
+                <span className="w-2 h-2 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "150ms" }} />
+                <span className="w-2 h-2 rounded-full bg-gray-300 animate-bounce" style={{ animationDelay: "300ms" }} />
+              </div>
+            </div>
+          </div>
+        </div>
+        {/* Footer badge */}
+        <div className="mt-4 bg-[#f0fdfa] border border-[#99f6e8] rounded-lg px-4 py-2 text-center">
+          <span className="text-teal-700 text-sm font-medium">⚡ {footerText}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChannelsSection() {
+  return (
+    <section className="py-20">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            Works where you already are
+          </h2>
+          <p className="text-[#6b7280] text-lg max-w-2xl mx-auto">
+            No app to download. No portal to learn. Just message — on WhatsApp, iMessage, or SMS.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+          <ChatMockup
+            platform="WhatsApp"
+            platformColor="#25D366"
+            platformIcon="💬"
+            agentMsg="New buyer — 3 bed Newton, $1.2M budget, needs good schools, moving from Brookline"
+            botMsg='Got it. Building buyer profile — budget $1.2M, 3-bed, Newton, school priority. Generating Top-5 report...'
+            footerText="Buyer report generated in ~10 seconds"
+          />
+          <ChatMockup
+            platform="iMessage / SMS"
+            platformColor="#34C759"
+            platformIcon="📱"
+            agentMsg="123 Main St, offer at $950K, closing June 15, $25K deposit, financing condition"
+            botMsg="Pulling property details for 123 Main St... Price, beds, baths ✓. Draft offer package ready for your review."
+            footerText="Draft offer package ready for review"
+          />
+        </div>
+
+        <div className="flex flex-wrap justify-center gap-8 mt-10 text-[#6b7280] text-sm">
+          <span className="flex items-center gap-2"><Smartphone className="h-4 w-4" /> No app to download</span>
+          <span className="flex items-center gap-2"><CheckCircle className="h-4 w-4" /> Works on any phone</span>
+          <span className="flex items-center gap-2"><Link2 className="h-4 w-4" /> One number for everything</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/DemoSection.tsx
+++ b/frontend/src/components/landing/DemoSection.tsx
@@ -1,26 +1,19 @@
+import ResidenceHiveDemo from "./ResidenceHiveDemo";
+
 export function DemoSection() {
   return (
-    <section id="how-it-works" className="py-16 sm:py-24 bg-gray-950">
+    <section id="demo" className="py-20 bg-[#f8faf9]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-10">
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
             See it in action
           </h2>
-          <p className="text-lg text-gray-400 max-w-2xl mx-auto">
-            Voice note to buyer report in under a minute. Watch the full loop.
+          <p className="text-[#6b7280] text-lg max-w-2xl mx-auto">
+            Voice note → buyer report → compliant chatbot → agent dashboard. The full loop in 60 seconds.
           </p>
         </div>
-
         <div className="flex justify-center">
-          <div className="w-full max-w-[820px] rounded-2xl overflow-hidden shadow-2xl shadow-black/50">
-            <iframe
-              src="/demo.html"
-              title="ResidenceHive Demo"
-              className="w-full border-0"
-              style={{ height: "780px" }}
-              allow="autoplay"
-            />
-          </div>
+          <ResidenceHiveDemo />
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/DemoSection.tsx
+++ b/frontend/src/components/landing/DemoSection.tsx
@@ -12,8 +12,11 @@ export function DemoSection() {
             Voice note → buyer report → compliant chatbot → agent dashboard. The full loop in 60 seconds.
           </p>
         </div>
-        <div className="flex justify-center">
-          <ResidenceHiveDemo />
+        {/* Scale down on mobile to fit viewport */}
+        <div className="flex justify-center overflow-hidden">
+          <div className="transform scale-[0.85] sm:scale-100 origin-top">
+            <ResidenceHiveDemo />
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/DifferentiatorsSection.tsx
+++ b/frontend/src/components/landing/DifferentiatorsSection.tsx
@@ -5,57 +5,41 @@ const capabilities = [
   "MLS-contextual responses",
   "Automatic intent capture",
   "Compliance guardrails",
-  "Risk detection & escalation",
+  "Risk detection and escalation",
+  "Market-specific form generation",
 ];
 
 export function DifferentiatorsSection() {
   return (
-    <section id="differentiators" className="py-16 sm:py-24 bg-gray-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Section Header */}
+    <section className="py-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
-          <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
             Why ResidenceHive?
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Generic AI hallucinates listings. ResidenceHive is built for compliance-first real estate.
+          <p className="text-[#6b7280] text-lg">
+            Generic AI hallucinates listings. Offer templates miss local requirements.
           </p>
         </div>
-
-        {/* Comparison Table */}
-        <div className="max-w-3xl mx-auto">
-          <div className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
-            {/* Table Header */}
-            <div className="grid grid-cols-3 bg-gray-50 border-b border-gray-200">
-              <div className="p-4 text-left">
-                <span className="font-semibold text-gray-900">Capability</span>
+        <div className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] overflow-hidden">
+          {/* Header */}
+          <div className="grid grid-cols-3 bg-gray-50 border-b border-[#e5e7eb]">
+            <div className="p-4 font-semibold text-[#111827] text-sm">Capability</div>
+            <div className="p-4 font-semibold text-[#111827] text-sm text-center">CRM + ChatGPT</div>
+            <div className="p-4 font-semibold text-[#111827] text-sm text-center">ResidenceHive</div>
+          </div>
+          {/* Rows */}
+          {capabilities.map((cap, i) => (
+            <div key={cap} className={`grid grid-cols-3 ${i % 2 === 1 ? "bg-gray-50" : "bg-white"} border-b border-[#e5e7eb] last:border-b-0`}>
+              <div className="p-4 text-sm text-[#111827]">{cap}</div>
+              <div className="p-4 flex justify-center">
+                <X className="h-5 w-5 text-red-500" />
               </div>
-              <div className="p-4 text-center border-l border-gray-200">
-                <span className="font-semibold text-gray-500">CRM + ChatGPT</span>
-              </div>
-              <div className="p-4 text-center border-l border-gray-200 bg-teal-50">
-                <span className="font-semibold text-teal-700">ResidenceHive</span>
+              <div className="p-4 flex justify-center">
+                <Check className="h-5 w-5 text-teal-600" />
               </div>
             </div>
-
-            {/* Table Rows */}
-            {capabilities.map((capability, index) => (
-              <div
-                key={index}
-                className={`grid grid-cols-3 ${index < capabilities.length - 1 ? "border-b border-gray-100" : ""}`}
-              >
-                <div className="p-4 text-left">
-                  <span className="text-gray-700">{capability}</span>
-                </div>
-                <div className="p-4 flex justify-center items-center border-l border-gray-100">
-                  <X className="h-5 w-5 text-gray-300" />
-                </div>
-                <div className="p-4 flex justify-center items-center border-l border-gray-100 bg-teal-50/50">
-                  <Check className="h-5 w-5 text-teal-600" />
-                </div>
-              </div>
-            ))}
-          </div>
+          ))}
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -3,15 +3,15 @@ import { Button } from "@/components/ui/button";
 
 function TodayCard() {
   return (
-    <div className="bg-white border border-[#fecaca] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-6 sm:p-7 opacity-[0.85] relative">
-      <span className="absolute top-4 right-4 px-2.5 py-1 rounded-md text-xs font-semibold uppercase bg-[#fef2f2] text-red-600">
+    <div className="bg-white border border-[#fecaca] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-4 sm:p-7 opacity-[0.85] relative">
+      <span className="absolute top-3 right-3 sm:top-4 sm:right-4 px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[10px] sm:text-xs font-semibold uppercase bg-[#fef2f2] text-red-600">
         Today
       </span>
-      <p className="text-[#9ca3af] text-xs uppercase tracking-wider font-semibold mb-3">
+      <p className="text-[#9ca3af] text-[10px] sm:text-xs uppercase tracking-wider font-semibold mb-2 sm:mb-3">
         What your leads get now
       </p>
       {/* Fake email mockup */}
-      <div className="bg-[#f9fafb] border border-[#e5e7eb] rounded-lg p-4 text-sm space-y-1.5 mb-5">
+      <div className="bg-[#f9fafb] border border-[#e5e7eb] rounded-lg p-3 sm:p-4 text-xs sm:text-sm space-y-1 sm:space-y-1.5 mb-4 sm:mb-5">
         <p className="text-[#6b7280]"><span className="font-medium text-[#111827]">From:</span> agent@brokerage.com</p>
         <p className="text-[#6b7280]"><span className="font-medium text-[#111827]">Subject:</span> Here are some listings for you!</p>
         <div className="border-t border-[#e5e7eb] pt-2 mt-2 space-y-1">
@@ -39,11 +39,11 @@ function WithRHCard() {
   ];
 
   return (
-    <div className="bg-white border-2 border-teal-600 rounded-[14px] shadow-[0_0_20px_rgba(13,148,136,0.12)] p-6 sm:p-7 relative">
-      <span className="absolute top-4 right-4 px-2.5 py-1 rounded-md text-xs font-semibold uppercase bg-[#f0fdfa] text-teal-700">
-        With ResidenceHive
+    <div className="bg-white border-2 border-teal-600 rounded-[14px] shadow-[0_0_20px_rgba(13,148,136,0.12)] p-4 sm:p-7 relative">
+      <span className="absolute top-3 right-3 sm:top-4 sm:right-4 px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[10px] sm:text-xs font-semibold uppercase bg-[#f0fdfa] text-teal-700">
+        ResidenceHive
       </span>
-      <p className="text-teal-700 text-xs uppercase tracking-wider font-semibold mb-3">
+      <p className="text-teal-700 text-[10px] sm:text-xs uppercase tracking-wider font-semibold mb-2 sm:mb-3">
         What your leads get instead
       </p>
       {/* Buyer report mockup */}
@@ -75,22 +75,22 @@ function WithRHCard() {
 
 export function HeroSection() {
   return (
-    <section className="pt-28 pb-16 bg-gradient-to-b from-[#f0fdfa] to-white">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="pt-28 pb-16 bg-gradient-to-b from-[#f0fdfa] to-white overflow-hidden">
+      <div className="max-w-6xl mx-auto px-3 sm:px-6 lg:px-8 overflow-hidden">
         {/* Badge */}
         <div className="text-center mb-6">
-          <span className="inline-block px-4 py-1.5 rounded-full text-sm font-medium text-teal-700 bg-[#f0fdfa] border border-[#99f6e8]">
+          <span className="inline-block px-3 sm:px-4 py-1 sm:py-1.5 rounded-full text-xs sm:text-sm font-medium text-teal-700 bg-[#f0fdfa] border border-[#99f6e8]">
             Now in Private Pilot — Massachusetts &amp; Ontario
           </span>
         </div>
 
         {/* Headline */}
-        <h1 className="text-3xl sm:text-4xl lg:text-[44px] font-bold text-[#111827] leading-tight text-center mb-10">
+        <h1 className="text-lg sm:text-4xl lg:text-[44px] font-bold text-[#111827] leading-snug text-center mb-6 sm:mb-10">
           Which one would <span className="text-teal-600">your buyer</span> respond to?
         </h1>
 
         {/* Before/After Cards */}
-        <div className="grid md:grid-cols-2 gap-6 mb-10">
+        <div className="grid md:grid-cols-2 gap-4 sm:gap-6 mb-8 sm:mb-10">
           <TodayCard />
           <WithRHCard />
         </div>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -3,13 +3,15 @@ import { Button } from "@/components/ui/button";
 
 function TodayCard() {
   return (
-    <div className="bg-white border border-[#fecaca] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-4 sm:p-7 opacity-[0.85] relative">
-      <span className="absolute top-3 right-3 sm:top-4 sm:right-4 px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[10px] sm:text-xs font-semibold uppercase bg-[#fef2f2] text-red-600">
-        Today
-      </span>
-      <p className="text-[#9ca3af] text-[10px] sm:text-xs uppercase tracking-wider font-semibold mb-2 sm:mb-3">
-        What your leads get now
-      </p>
+    <div className="bg-white border border-[#fecaca] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-4 sm:p-7 opacity-[0.85]">
+      <div className="flex items-center justify-between mb-2 sm:mb-3">
+        <p className="text-[#9ca3af] text-[10px] sm:text-xs uppercase tracking-wider font-semibold">
+          What your leads get now
+        </p>
+        <span className="px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[9px] sm:text-xs font-semibold uppercase bg-[#fef2f2] text-red-600 shrink-0 ml-2">
+          Today
+        </span>
+      </div>
       {/* Fake email mockup */}
       <div className="bg-[#f9fafb] border border-[#e5e7eb] rounded-lg p-3 sm:p-4 text-xs sm:text-sm space-y-1 sm:space-y-1.5 mb-4 sm:mb-5">
         <p className="text-[#6b7280]"><span className="font-medium text-[#111827]">From:</span> agent@brokerage.com</p>
@@ -39,13 +41,15 @@ function WithRHCard() {
   ];
 
   return (
-    <div className="bg-white border-2 border-teal-600 rounded-[14px] shadow-[0_0_20px_rgba(13,148,136,0.12)] p-4 sm:p-7 relative">
-      <span className="absolute top-3 right-3 sm:top-4 sm:right-4 px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[10px] sm:text-xs font-semibold uppercase bg-[#f0fdfa] text-teal-700">
-        ResidenceHive
-      </span>
-      <p className="text-teal-700 text-[10px] sm:text-xs uppercase tracking-wider font-semibold mb-2 sm:mb-3">
-        What your leads get instead
-      </p>
+    <div className="bg-white border-2 border-teal-600 rounded-[14px] shadow-[0_0_20px_rgba(13,148,136,0.12)] p-4 sm:p-7">
+      <div className="flex items-center justify-between mb-2 sm:mb-3">
+        <p className="text-teal-700 text-[10px] sm:text-xs uppercase tracking-wider font-semibold">
+          What your leads get instead
+        </p>
+        <span className="px-2 py-0.5 sm:px-2.5 sm:py-1 rounded-md text-[9px] sm:text-xs font-semibold uppercase bg-[#f0fdfa] text-teal-700 shrink-0 ml-2">
+          With ResidenceHive
+        </span>
+      </div>
       {/* Buyer report mockup */}
       <div className="bg-[#f0fdfa] border border-[#99f6e8] rounded-lg p-4 mb-5">
         <p className="font-semibold text-[#111827] text-sm mb-1">Personalized Buyer Report for Michael</p>

--- a/frontend/src/components/landing/HeroSection.tsx
+++ b/frontend/src/components/landing/HeroSection.tsx
@@ -1,106 +1,132 @@
-import { useState } from "react";
-import { ArrowRight, AlertCircle } from "lucide-react";
+import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { DemoRequestModal } from "./DemoRequestModal";
-import ResidenceHiveDemo from "./ResidenceHiveDemo";
 
-export function HeroSection() {
-  const [demoModalOpen, setDemoModalOpen] = useState(false);
-
+function TodayCard() {
   return (
-    <section id="how-it-works" className="relative min-h-screen flex items-center pt-16 bg-gradient-to-br from-teal-50 to-cyan-100 overflow-hidden">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 sm:py-20">
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12 items-center">
-
-          {/* Left — Content */}
-          <div className="text-center lg:text-left">
-            <Badge variant="secondary" className="mb-6 px-4 py-2 text-sm bg-white/80 text-teal-700 border border-teal-200">
-              Now in private pilot
-            </Badge>
-
-            <h1 className="text-4xl sm:text-5xl lg:text-4xl xl:text-5xl font-bold text-gray-900 tracking-tight mb-5">
-              Your buyers deserve better than a listing dump
-            </h1>
-
-            <p className="text-base sm:text-lg text-gray-600 mb-4 leading-relaxed">
-              Leads go cold because agents send 50 listings and hope for the best.
-              ResidenceHive sends a personalized buyer report — properties ranked by
-              their criteria, AI photo analysis that catches what agents miss, and
-              honest market explanations that build trust.
-            </p>
-
-            <p className="text-base sm:text-lg font-semibold text-gray-800 mb-6">
-              Buyers respond because someone finally did the work. Agents close more
-              because buyers show up informed and ready to tour.
-            </p>
-
-            <div className="flex flex-col sm:flex-row gap-3 justify-center lg:justify-start mb-6">
-              <Button
-                size="lg"
-                className="text-base px-7 py-5 h-auto bg-gray-900 hover:bg-gray-800"
-                onClick={() => setDemoModalOpen(true)}
-              >
-                Request demo
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
-            </div>
-
-            {/* Math comparison card */}
-            <div className="bg-white/80 backdrop-blur-sm rounded-xl border border-gray-200 p-4 max-w-lg">
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                The math your brokerage is living
-              </p>
-              <div className="grid grid-cols-3 gap-3 mb-3">
-                <div className="text-center">
-                  <div className="text-lg font-bold text-red-600 line-through decoration-2">$50-80</div>
-                  <div className="text-xs text-gray-500">per lead</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-bold text-red-600 line-through decoration-2">0.5%</div>
-                  <div className="text-xs text-gray-500">convert with listing dumps</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-bold text-red-600 line-through decoration-2">$16,000</div>
-                  <div className="text-xs text-gray-500">lead cost per closing</div>
-                </div>
-              </div>
-              <div className="grid grid-cols-3 gap-3 pt-3 border-t border-gray-100">
-                <div className="text-center">
-                  <div className="text-lg font-bold text-green-700">60s</div>
-                  <div className="text-xs text-gray-500">response time</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-bold text-green-700">2-4%</div>
-                  <div className="text-xs text-gray-500">convert with personalized reports</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-lg font-bold text-green-700">$2,000</div>
-                  <div className="text-xs text-gray-500">lead cost per closing</div>
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 mt-4">
-              <div className="w-2 h-2 rounded-full bg-blue-500" />
-              <span className="text-sm text-gray-600">
-                No CRM login. No new workflow. Voice note on WhatsApp → report in their inbox.
-              </span>
-            </div>
-          </div>
-
-          {/* Right — Demo */}
-          <div className="hidden lg:flex justify-center lg:justify-end">
-            <ResidenceHiveDemo />
-          </div>
-
+    <div className="bg-white border border-[#fecaca] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-6 sm:p-7 opacity-[0.85] relative">
+      <span className="absolute top-4 right-4 px-2.5 py-1 rounded-md text-xs font-semibold uppercase bg-[#fef2f2] text-red-600">
+        Today
+      </span>
+      <p className="text-[#9ca3af] text-xs uppercase tracking-wider font-semibold mb-3">
+        What your leads get now
+      </p>
+      {/* Fake email mockup */}
+      <div className="bg-[#f9fafb] border border-[#e5e7eb] rounded-lg p-4 text-sm space-y-1.5 mb-5">
+        <p className="text-[#6b7280]"><span className="font-medium text-[#111827]">From:</span> agent@brokerage.com</p>
+        <p className="text-[#6b7280]"><span className="font-medium text-[#111827]">Subject:</span> Here are some listings for you!</p>
+        <div className="border-t border-[#e5e7eb] pt-2 mt-2 space-y-1">
+          <p className="text-[#6b7280]">123 Main St — $850K — 3bd/2ba</p>
+          <p className="text-[#6b7280]">456 Oak Ave — $920K — 4bd/2ba</p>
+          <p className="text-[#6b7280]">789 Elm Dr — $780K — 3bd/1ba</p>
+          <p className="text-[#6b7280]">321 Pine Rd — $1.1M — 4bd/3ba</p>
+          <p className="text-[#9ca3af] italic text-xs">... and 26 more listings</p>
         </div>
       </div>
+      <div className="text-center">
+        <span className="text-2xl">🗑️</span>
+        <p className="text-red-500 font-bold text-sm mt-1">Buyer never opens it</p>
+        <p className="text-[#9ca3af] text-xs">$200 lead — gone</p>
+      </div>
+    </div>
+  );
+}
 
-      {/* Bottom gradient fade */}
-      <div className="absolute bottom-0 left-0 right-0 h-24 bg-gradient-to-t from-white to-transparent" />
+function WithRHCard() {
+  const listings = [
+    { rank: "#1", address: "60 Lindbergh Ave, Newton", reason: "Best school match + under budget" },
+    { rank: "#2", address: "14 Oak Hill Rd, Newton", reason: "Larger lot, needs some updating" },
+    { rank: "#3", address: "88 Crafts St, Newtonville", reason: "Walk to village, above budget by 5%" },
+  ];
 
-      <DemoRequestModal open={demoModalOpen} onOpenChange={setDemoModalOpen} />
+  return (
+    <div className="bg-white border-2 border-teal-600 rounded-[14px] shadow-[0_0_20px_rgba(13,148,136,0.12)] p-6 sm:p-7 relative">
+      <span className="absolute top-4 right-4 px-2.5 py-1 rounded-md text-xs font-semibold uppercase bg-[#f0fdfa] text-teal-700">
+        With ResidenceHive
+      </span>
+      <p className="text-teal-700 text-xs uppercase tracking-wider font-semibold mb-3">
+        What your leads get instead
+      </p>
+      {/* Buyer report mockup */}
+      <div className="bg-[#f0fdfa] border border-[#99f6e8] rounded-lg p-4 mb-5">
+        <p className="font-semibold text-[#111827] text-sm mb-1">Personalized Buyer Report for Michael</p>
+        <p className="text-teal-700 text-xs font-bold mb-3">Top 5 picks — ranked for you</p>
+        <div className="space-y-2.5">
+          {listings.map((l) => (
+            <div key={l.rank} className="flex items-start gap-2.5">
+              <span className="bg-white text-teal-700 text-xs font-bold px-2 py-0.5 rounded shrink-0 border border-[#99f6e8]">
+                {l.rank}
+              </span>
+              <div>
+                <p className="text-sm font-medium text-[#111827]">{l.address}</p>
+                <p className="text-xs text-[#6b7280]">{l.reason}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="text-center">
+        <span className="text-2xl">💬</span>
+        <p className="text-teal-600 font-bold text-sm mt-1">Buyer engages instantly</p>
+        <p className="text-[#9ca3af] text-xs">Asks about schools, schedules showing</p>
+      </div>
+    </div>
+  );
+}
+
+export function HeroSection() {
+  return (
+    <section className="pt-28 pb-16 bg-gradient-to-b from-[#f0fdfa] to-white">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Badge */}
+        <div className="text-center mb-6">
+          <span className="inline-block px-4 py-1.5 rounded-full text-sm font-medium text-teal-700 bg-[#f0fdfa] border border-[#99f6e8]">
+            Now in Private Pilot — Massachusetts &amp; Ontario
+          </span>
+        </div>
+
+        {/* Headline */}
+        <h1 className="text-3xl sm:text-4xl lg:text-[44px] font-bold text-[#111827] leading-tight text-center mb-10">
+          Which one would <span className="text-teal-600">your buyer</span> respond to?
+        </h1>
+
+        {/* Before/After Cards */}
+        <div className="grid md:grid-cols-2 gap-6 mb-10">
+          <TodayCard />
+          <WithRHCard />
+        </div>
+
+        {/* Bottom text + CTA */}
+        <div className="text-center">
+          <p className="text-[#6b7280] text-base mb-6">
+            AI handles the first response and offer prep. <span className="font-bold text-[#111827]">Your agents handle the relationship.</span>
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mb-6">
+            <button
+              onClick={() => document.getElementById("how-it-works")?.scrollIntoView({ behavior: "smooth" })}
+              className="inline-flex items-center justify-center rounded-md bg-teal-600 hover:bg-teal-700 text-white shadow-lg px-8 py-3 text-base font-medium transition-colors"
+            >
+              See How It Works
+            </button>
+            <button
+              onClick={() => document.getElementById("demo")?.scrollIntoView({ behavior: "smooth" })}
+              className="inline-flex items-center justify-center text-teal-600 hover:text-teal-700 font-medium text-base transition-colors"
+            >
+              Watch the demo →
+            </button>
+          </div>
+          <div className="flex flex-wrap justify-center gap-3">
+            {[
+              { emoji: "🎯", text: "60-day free pilot" },
+              { emoji: "✅", text: "No contracts" },
+              { emoji: "💬", text: "WhatsApp + iMessage" },
+            ].map((pill) => (
+              <span key={pill.text} className="inline-flex items-center gap-1.5 px-4 py-2 bg-white border border-[#e5e7eb] rounded-full text-sm font-semibold text-[#111827]">
+                {pill.emoji} {pill.text}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
     </section>
   );
 }

--- a/frontend/src/components/landing/HowItWorksSection.tsx
+++ b/frontend/src/components/landing/HowItWorksSection.tsx
@@ -1,110 +1,46 @@
-import { ArrowRight, Inbox, Brain, FileText, MessageSquare, UserCheck } from "lucide-react";
+import { StepsCard } from "./StepsCard";
 
-const steps = [
-  {
-    icon: Inbox,
-    number: 1,
-    title: "Lead Arrives",
-    description: "From website, Zillow, Realtor.com, or referral",
-  },
-  {
-    icon: Brain,
-    number: 2,
-    title: "AI Analyzes",
-    description: "Extracts budget, timeline, must-haves, dealbreakers",
-  },
-  {
-    icon: FileText,
-    number: 3,
-    title: "Report Generated",
-    description: "Curated Top-5 with personalized explanations",
-  },
-  {
-    icon: MessageSquare,
-    number: 4,
-    title: "Buyer Engages",
-    description: "Chatbot answers questions within compliance guardrails",
-  },
-  {
-    icon: UserCheck,
-    number: 5,
-    title: "Agent Acts",
-    description: "Receive qualified lead with full context - ready for action",
-  },
+const leadSteps = [
+  { number: "01", title: "Lead arrives", description: "From your website, Zillow, Realtor.com, or a referral" },
+  { number: "02", title: "AI analyzes", description: "Extracts budget, timeline, must-haves, dealbreakers" },
+  { number: "03", title: "Report generated", description: "Curated Top-5 listings with personalized explanations" },
+  { number: "04", title: "Buyer engages", description: "Chatbot answers questions within compliance guardrails" },
+  { number: "05", title: "Agent acts", description: "Qualified lead with full context — ready for action" },
+];
+
+const offerSteps = [
+  { number: "01", title: "Agent sends deal details", description: "Natural language via WhatsApp — no forms" },
+  { number: "02", title: "System extracts", description: "Price, conditions, dates, parties, clauses" },
+  { number: "03", title: "Missing fields flagged", description: "AI asks for what's incomplete" },
+  { number: "04", title: "Draft package generated", description: "Pre-filled forms ready for agent review" },
+  { number: "05", title: "Agent reviews and sends", description: "Nothing goes out without agent approval" },
 ];
 
 export function HowItWorksSection() {
   return (
-    <section id="how-it-works" className="py-16 sm:py-24 bg-white">
+    <section id="how-it-works" className="py-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Section Header */}
         <div className="text-center mb-12">
-          <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
-            How it works
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            Two products. One platform.
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            From lead to qualified buyer in five seamless steps.
+          <p className="text-[#6b7280] text-lg">
+            Both built for compliance-first real estate.
           </p>
         </div>
-
-        {/* Desktop Flow - Horizontal */}
-        <div className="hidden lg:flex items-start justify-between">
-          {steps.map((step, index) => (
-            <div key={index} className="flex items-start">
-              {/* Step */}
-              <div className="flex flex-col items-center text-center max-w-[180px]">
-                <div className="w-16 h-16 rounded-full bg-teal-600 flex items-center justify-center mb-4 relative">
-                  <step.icon className="h-8 w-8 text-white" />
-                  <span className="absolute -top-2 -right-2 w-6 h-6 bg-gray-900 rounded-full flex items-center justify-center text-white text-xs font-bold">
-                    {step.number}
-                  </span>
-                </div>
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                  {step.title}
-                </h3>
-                <p className="text-sm text-gray-600">
-                  {step.description}
-                </p>
-              </div>
-
-              {/* Arrow (except last) */}
-              {index < steps.length - 1 && (
-                <div className="flex-shrink-0 pt-6 px-4">
-                  <ArrowRight className="h-6 w-6 text-gray-300" />
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-
-        {/* Mobile Flow - Vertical */}
-        <div className="lg:hidden space-y-8">
-          {steps.map((step, index) => (
-            <div key={index} className="flex gap-4">
-              {/* Step Number and Line */}
-              <div className="flex flex-col items-center">
-                <div className="w-12 h-12 rounded-full bg-teal-600 flex items-center justify-center relative flex-shrink-0">
-                  <step.icon className="h-6 w-6 text-white" />
-                  <span className="absolute -top-1 -right-1 w-5 h-5 bg-gray-900 rounded-full flex items-center justify-center text-white text-xs font-bold">
-                    {step.number}
-                  </span>
-                </div>
-                {index < steps.length - 1 && (
-                  <div className="w-0.5 h-full bg-gray-200 mt-2" />
-                )}
-              </div>
-
-              {/* Content */}
-              <div className="pb-8">
-                <h3 className="text-lg font-semibold text-gray-900 mb-1">
-                  {step.title}
-                </h3>
-                <p className="text-gray-600">
-                  {step.description}
-                </p>
-              </div>
-            </div>
-          ))}
+        <div className="grid md:grid-cols-2 gap-8">
+          <StepsCard
+            label="Lead Engagement"
+            subtitle="Turn raw leads into qualified buyers with AI-powered first response."
+            steps={leadSteps}
+            accentColor="teal"
+          />
+          <StepsCard
+            label="Offer Bot"
+            subtitle="Go from a listing address to a draft-ready offer package in minutes."
+            steps={offerSteps}
+            accentColor="blue"
+          />
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/LandingNav.tsx
+++ b/frontend/src/components/landing/LandingNav.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import { Link } from "wouter";
-import { Building2, Menu } from "lucide-react";
+import { Building2, Menu, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
-import { DemoRequestModal } from "./DemoRequestModal";
 
 export function LandingNav() {
   const [open, setOpen] = useState(false);
-  const [demoModalOpen, setDemoModalOpen] = useState(false);
+  const [marketsOpen, setMarketsOpen] = useState(false);
 
   const scrollToSection = (sectionId: string) => {
     const element = document.getElementById(sectionId);
@@ -17,96 +16,111 @@ export function LandingNav() {
     setOpen(false);
   };
 
-  const handleDemoClick = () => {
-    setOpen(false);
-    setDemoModalOpen(true);
-  };
-
   return (
-    <>
-      <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between h-16">
-            {/* Logo */}
-            <Link href="/" className="flex items-center gap-2">
-              <Building2 className="h-8 w-8 text-teal-600" />
-              <span className="font-semibold text-xl text-gray-900">ResidenceHive</span>
-            </Link>
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-100">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between h-16">
+          {/* Logo */}
+          <Link href="/" className="flex items-center gap-2">
+            <Building2 className="h-8 w-8 text-teal-600" />
+            <span className="font-semibold text-xl text-gray-900">ResidenceHive</span>
+          </Link>
 
-            {/* Desktop Navigation */}
-            <div className="hidden md:flex items-center gap-8">
-              <button
-                onClick={() => scrollToSection("how-it-works")}
-                className="text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                How It Works
+          {/* Desktop Navigation */}
+          <div className="hidden md:flex items-center gap-8">
+            {/* Markets Dropdown */}
+            <div
+              className="relative group"
+              onMouseEnter={() => setMarketsOpen(true)}
+              onMouseLeave={() => setMarketsOpen(false)}
+            >
+              <button className="flex items-center gap-1 text-gray-600 hover:text-gray-900 transition-colors">
+                Markets <ChevronDown className="h-4 w-4" />
               </button>
-              <button
-                onClick={() => scrollToSection("features")}
-                className="text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Features
-              </button>
-              <button
-                onClick={() => scrollToSection("differentiators")}
-                className="text-gray-600 hover:text-gray-900 transition-colors"
-              >
-                Why Us
-              </button>
-            </div>
-
-            {/* Desktop CTAs */}
-            <div className="hidden md:flex items-center gap-4">
-              <a href="/sign-in">
-                <Button variant="ghost">Sign In</Button>
-              </a>
-              <Button onClick={() => setDemoModalOpen(true)}>Request Demo</Button>
-            </div>
-
-            {/* Mobile Menu */}
-            <Sheet open={open} onOpenChange={setOpen}>
-              <SheetTrigger asChild className="md:hidden">
-                <Button variant="ghost" size="icon">
-                  <Menu className="h-6 w-6" />
-                </Button>
-              </SheetTrigger>
-              <SheetContent side="right" className="w-[280px]">
-                <div className="flex flex-col gap-6 mt-8">
-                  <button
-                    onClick={() => scrollToSection("how-it-works")}
-                    className="text-left text-lg text-gray-600 hover:text-gray-900 transition-colors"
+              {marketsOpen && (
+                <div className="absolute top-full left-0 mt-1 w-48 bg-white border border-gray-200 rounded-lg shadow-lg py-2">
+                  <a
+                    href="/massachusetts"
+                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                   >
-                    How It Works
-                  </button>
-                  <button
-                    onClick={() => scrollToSection("features")}
-                    className="text-left text-lg text-gray-600 hover:text-gray-900 transition-colors"
+                    Massachusetts
+                  </a>
+                  <a
+                    href="/ontario"
+                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 hover:text-gray-900"
                   >
-                    Features
-                  </button>
-                  <button
-                    onClick={() => scrollToSection("differentiators")}
-                    className="text-left text-lg text-gray-600 hover:text-gray-900 transition-colors"
-                  >
-                    Why Us
-                  </button>
-                  <div className="border-t pt-6 flex flex-col gap-3">
-                    <a href="/sign-in">
-                      <Button variant="outline" className="w-full">Sign In</Button>
-                    </a>
-                    <Button className="w-full" onClick={handleDemoClick}>
-                      Request Demo
-                    </Button>
-                  </div>
+                    Ontario
+                  </a>
                 </div>
-              </SheetContent>
-            </Sheet>
+              )}
+            </div>
+            <a href="/offer-bot" className="text-gray-600 hover:text-gray-900 transition-colors">
+              Offer Bot
+            </a>
+            <button
+              onClick={() => scrollToSection("how-it-works")}
+              className="text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              How It Works
+            </button>
           </div>
-        </div>
-      </nav>
 
-      {/* Demo Request Modal */}
-      <DemoRequestModal open={demoModalOpen} onOpenChange={setDemoModalOpen} />
-    </>
+          {/* Desktop CTAs */}
+          <div className="hidden md:flex items-center gap-4">
+            <a href="/sign-in">
+              <Button variant="ghost">Sign In</Button>
+            </a>
+            <a href="/sign-up">
+              <Button>Request Demo</Button>
+            </a>
+          </div>
+
+          {/* Mobile Menu */}
+          <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild className="md:hidden">
+              <Button variant="ghost" size="icon">
+                <Menu className="h-6 w-6" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="right" className="w-[280px]">
+              <div className="flex flex-col gap-6 mt-8">
+                {/* Markets expandable */}
+                <div>
+                  <button
+                    onClick={() => setMarketsOpen(!marketsOpen)}
+                    className="flex items-center gap-1 text-left text-lg text-gray-600 hover:text-gray-900 transition-colors"
+                  >
+                    Markets <ChevronDown className={`h-4 w-4 transition-transform ${marketsOpen ? "rotate-180" : ""}`} />
+                  </button>
+                  {marketsOpen && (
+                    <div className="ml-4 mt-2 flex flex-col gap-2">
+                      <a href="/massachusetts" className="text-gray-500 hover:text-gray-900">Massachusetts</a>
+                      <a href="/ontario" className="text-gray-500 hover:text-gray-900">Ontario</a>
+                    </div>
+                  )}
+                </div>
+                <a href="/offer-bot" className="text-left text-lg text-gray-600 hover:text-gray-900 transition-colors">
+                  Offer Bot
+                </a>
+                <button
+                  onClick={() => scrollToSection("how-it-works")}
+                  className="text-left text-lg text-gray-600 hover:text-gray-900 transition-colors"
+                >
+                  How It Works
+                </button>
+                <div className="border-t pt-6 flex flex-col gap-3">
+                  <a href="/sign-in">
+                    <Button variant="outline" className="w-full">Sign In</Button>
+                  </a>
+                  <a href="/sign-up">
+                    <Button className="w-full">Request Demo</Button>
+                  </a>
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
+        </div>
+      </div>
+    </nav>
   );
 }

--- a/frontend/src/components/landing/MarketCTA.tsx
+++ b/frontend/src/components/landing/MarketCTA.tsx
@@ -1,0 +1,30 @@
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+
+interface MarketCTAProps {
+  headline: string;
+  subtext: string;
+  ctaText?: string;
+  ctaHref?: string;
+}
+
+export function MarketCTA({
+  headline,
+  subtext,
+  ctaText = "Request Demo",
+  ctaHref = "/sign-up",
+}: MarketCTAProps) {
+  return (
+    <section className="py-20 bg-gradient-to-b from-white to-[#f0fdfa]">
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">{headline}</h2>
+        <p className="text-[#6b7280] text-lg mb-8">{subtext}</p>
+        <Link href={ctaHref}>
+          <Button size="lg" className="bg-teal-600 hover:bg-teal-700 text-white shadow-lg px-8 py-3 text-base">
+            {ctaText}
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/MarketHero.tsx
+++ b/frontend/src/components/landing/MarketHero.tsx
@@ -1,0 +1,46 @@
+import { Link } from "wouter";
+import { Button } from "@/components/ui/button";
+
+interface MarketHeroProps {
+  badge?: string;
+  headline: string;
+  subhead: string;
+  statCallout?: string;
+  ctaText?: string;
+  ctaHref?: string;
+}
+
+export function MarketHero({
+  badge,
+  headline,
+  subhead,
+  statCallout,
+  ctaText = "Request Demo",
+  ctaHref = "/sign-up",
+}: MarketHeroProps) {
+  return (
+    <section className="pt-28 pb-16 bg-gradient-to-b from-[#f0fdfa] to-white">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        {badge && (
+          <span className="inline-block px-4 py-1.5 rounded-full text-sm font-medium text-teal-700 bg-[#f0fdfa] border border-[#99f6e8] mb-6">
+            {badge}
+          </span>
+        )}
+        <h1 className="text-4xl sm:text-5xl font-bold text-[#111827] leading-tight mb-6">
+          {headline}
+        </h1>
+        <p className="text-lg text-[#6b7280] max-w-2xl mx-auto mb-8">
+          {subhead}
+        </p>
+        {statCallout && (
+          <p className="text-teal-600 font-semibold text-lg mb-8">{statCallout}</p>
+        )}
+        <Link href={ctaHref}>
+          <Button size="lg" className="bg-teal-600 hover:bg-teal-700 text-white shadow-lg px-8 py-3 text-base">
+            {ctaText}
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/MarketsSection.tsx
+++ b/frontend/src/components/landing/MarketsSection.tsx
@@ -1,0 +1,79 @@
+import { Check, ArrowRight } from "lucide-react";
+
+function MarketCard({
+  flag,
+  title,
+  description,
+  features,
+  linkText,
+  linkHref,
+}: {
+  flag: string;
+  title: string;
+  description: string;
+  features: string[];
+  linkText: string;
+  linkHref: string;
+}) {
+  return (
+    <div className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7 sm:p-8">
+      <div className="text-3xl mb-3">{flag}</div>
+      <h3 className="text-xl font-bold text-[#111827] mb-3">{title}</h3>
+      <p className="text-[#6b7280] text-sm mb-5">{description}</p>
+      <div className="space-y-2 mb-6">
+        {features.map((f) => (
+          <div key={f} className="flex items-start gap-2">
+            <Check className="h-4 w-4 text-teal-600 mt-0.5 shrink-0" />
+            <span className="text-sm text-[#111827]">{f}</span>
+          </div>
+        ))}
+      </div>
+      <a href={linkHref} className="text-teal-600 font-medium text-sm hover:text-teal-700 flex items-center gap-1">
+        {linkText} <ArrowRight className="h-4 w-4" />
+      </a>
+    </div>
+  );
+}
+
+export function MarketsSection() {
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            Localized for the markets you work in
+          </h2>
+          <p className="text-[#6b7280] text-lg max-w-2xl mx-auto">
+            Forms, compliance rules, and agent workflows differ by market. ResidenceHive is built for each one.
+          </p>
+        </div>
+        <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+          <MarketCard
+            flag="🇺🇸"
+            title="Massachusetts"
+            description="Purpose-built for MA agents. MLS PIN data, local compliance guardrails, and buyer engagement workflows designed for how Massachusetts transactions actually work."
+            features={[
+              "Lead intake and buyer qualification",
+              "Compliance-first chatbot with Fair Housing guardrails",
+              "MLS-contextual buyer reports",
+            ]}
+            linkText="See Massachusetts"
+            linkHref="/massachusetts"
+          />
+          <MarketCard
+            flag="🇨🇦"
+            title="Ontario"
+            description="Built around Ontario agent workflows. From buyer engagement to draft offer packages — localized for how Ontario deals move."
+            features={[
+              "Lead engagement and buyer intake",
+              "Listing-aware offer preparation",
+              "Draft OREA form generation for agent review",
+            ]}
+            linkText="See Ontario"
+            linkHref="/ontario"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/NumbersBar.tsx
+++ b/frontend/src/components/landing/NumbersBar.tsx
@@ -11,9 +11,9 @@ export function NumbersBar() {
       <div className="max-w-7xl mx-auto">
         <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-[#e5e7eb]">
           {stats.map((stat) => (
-            <div key={stat.label} className="bg-white py-8 px-6 text-center">
-              <div className="text-2xl sm:text-3xl font-bold text-teal-600 mb-1">{stat.number}</div>
-              <div className="text-sm text-[#9ca3af]">{stat.label}</div>
+            <div key={stat.label} className="bg-white py-6 sm:py-8 px-3 sm:px-6 text-center">
+              <div className="text-xl sm:text-3xl font-bold text-teal-600 mb-1">{stat.number}</div>
+              <div className="text-xs sm:text-sm text-[#9ca3af]">{stat.label}</div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/landing/NumbersBar.tsx
+++ b/frontend/src/components/landing/NumbersBar.tsx
@@ -1,0 +1,23 @@
+const stats = [
+  { number: "$100–225+", label: "Cost per lead" },
+  { number: "78%", label: "Get no personalized response" },
+  { number: "30–40", label: "Unranked listings per reply" },
+  { number: "~15 min", label: "Saved per listing" },
+];
+
+export function NumbersBar() {
+  return (
+    <section className="border-y border-[#e5e7eb]">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-4 divide-x divide-[#e5e7eb]">
+          {stats.map((stat) => (
+            <div key={stat.label} className="bg-white py-8 px-6 text-center">
+              <div className="text-2xl sm:text-3xl font-bold text-teal-600 mb-1">{stat.number}</div>
+              <div className="text-sm text-[#9ca3af]">{stat.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/ProblemSection.tsx
+++ b/frontend/src/components/landing/ProblemSection.tsx
@@ -1,56 +1,122 @@
-import { DollarSign, MessageSquareX, ClipboardList } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
+import { Home, Zap, X } from "lucide-react";
 
-const problems = [
-  {
-    icon: DollarSign,
-    title: "Expensive, Ignored",
-    description: "Brokerages pay $100-225+ per lead. Most never get a meaningful response.",
-  },
-  {
-    icon: MessageSquareX,
-    title: "Generic Replies",
-    description: "Buyers get 30-40 unranked listings with no explanation or trade-offs. It looks like spam.",
-  },
-  {
-    icon: ClipboardList,
-    title: "Lost Intent",
-    description: "Buyer questions reveal timeline, budget, must-haves. Traditional CRMs capture none of it.",
-  },
-];
+function ProblemCard({
+  icon,
+  label,
+  costNumber,
+  costSuffix,
+  shouldBe,
+  stuckDoing,
+  costLine,
+  bullets,
+  fixLine,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  costNumber: string;
+  costSuffix: string;
+  shouldBe: string;
+  stuckDoing: string;
+  costLine: string;
+  bullets: string[];
+  fixLine: string;
+}) {
+  return (
+    <div className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7 sm:p-8">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2">
+          {icon}
+          <span className="text-teal-700 font-semibold text-xs uppercase tracking-wider">{label}</span>
+        </div>
+        <div className="text-right">
+          <span className="text-red-500 font-bold text-lg">{costNumber}</span>
+          <span className="text-[#6b7280] text-sm ml-1">{costSuffix}</span>
+        </div>
+      </div>
+
+      {/* Green box */}
+      <div className="bg-[#f0fdfa] border border-[#99f6e8] rounded-lg p-4 mb-3">
+        <div className="text-teal-700 text-xs font-semibold uppercase tracking-wider mb-1">Your agent should be</div>
+        <div className="text-[#111827] text-sm">{shouldBe}</div>
+      </div>
+
+      {/* Red box */}
+      <div className="bg-[#fef2f2] border border-[#fecaca] rounded-lg p-4 mb-4">
+        <div className="text-red-600 text-xs font-semibold uppercase tracking-wider mb-1">Instead they're stuck</div>
+        <div className="text-[#111827] text-sm">{stuckDoing}</div>
+      </div>
+
+      {/* Cost line */}
+      <p className="text-sm italic text-[#6b7280] mb-4">{costLine}</p>
+
+      {/* Red bullets */}
+      <div className="space-y-2 mb-5">
+        {bullets.map((b) => (
+          <div key={b} className="flex items-start gap-2">
+            <X className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+            <span className="text-sm text-[#111827]">{b}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Fix box */}
+      <div className="bg-gray-50 border-l-4 border-teal-600 rounded-r-lg p-4">
+        <p className="text-sm text-[#111827]">{fixLine}</p>
+      </div>
+    </div>
+  );
+}
 
 export function ProblemSection() {
   return (
-    <section className="py-16 sm:py-24 bg-white">
+    <section className="py-20">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Section Header */}
         <div className="text-center mb-12">
-          <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
-            The problem with lead response today
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            Your agents should be closing — not typing
           </h2>
-          <p className="text-lg text-gray-600 max-w-2xl mx-auto">
-            Real estate leads are expensive, but most brokerages struggle to respond effectively.
+          <p className="text-[#6b7280] text-lg max-w-2xl mx-auto">
+            Every minute on busywork is a minute not spent with a buyer. Let your agents do what they're great at.
           </p>
         </div>
 
-        {/* Problem Cards */}
-        <div className="grid md:grid-cols-3 gap-6">
-          {problems.map((problem, index) => (
-            <Card key={index} className="border-gray-200 hover:border-gray-300 transition-colors">
-              <CardContent className="pt-6">
-                <div className="w-12 h-12 rounded-lg bg-red-50 flex items-center justify-center mb-4">
-                  <problem.icon className="h-6 w-6 text-red-600" />
-                </div>
-                <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                  {problem.title}
-                </h3>
-                <p className="text-gray-600">
-                  {problem.description}
-                </p>
-              </CardContent>
-            </Card>
-          ))}
+        <div className="grid md:grid-cols-2 gap-8">
+          <ProblemCard
+            icon={<Home className="h-5 w-5 text-teal-600" />}
+            label="Lead Engagement"
+            costNumber="$100–225+"
+            costSuffix="per lead — gone"
+            shouldBe="Showing homes. Building relationships. Converting."
+            stuckDoing="Copy-pasting 30 listings into an email no one reads."
+            costLine="78% of leads ghost before your agent even picks up the phone."
+            bullets={[
+              "Generic listing dump — buyer sees spam",
+              "Zero intent captured — CRM gets a name and nothing else",
+              "No follow-up — lead goes to Zillow's ChatGPT",
+            ]}
+            fixLine="ResidenceHive handles the first response. Your agent steps in when the buyer is ready to talk."
+          />
+          <ProblemCard
+            icon={<Zap className="h-5 w-5 text-teal-600" />}
+            label="Offer Prep"
+            costNumber="~15 min"
+            costSuffix="per offer — wasted"
+            shouldBe="Fighting to submit on tight deadlines. Winning deals."
+            stuckDoing="Retyping property details into blank forms at midnight."
+            costLine="Multiply that by 3 competing offers on a Friday night."
+            bullets={[
+              "Manual data entry across multiple forms",
+              "Missing a clause = deal falls through",
+              "Agent time burned on paperwork, not negotiation",
+            ]}
+            fixLine="ResidenceHive preps the draft. Your agent reviews, edits, and sends — in minutes, not hours."
+          />
         </div>
+
+        <p className="text-center text-teal-600 font-bold text-lg mt-12">
+          Your agents close deals. We handle the rest.
+        </p>
       </div>
     </section>
   );

--- a/frontend/src/components/landing/SmartResponseSection.tsx
+++ b/frontend/src/components/landing/SmartResponseSection.tsx
@@ -1,0 +1,34 @@
+import { Target, MessageCircle, Brain, Link2 } from "lucide-react";
+
+const features = [
+  { icon: Target, title: "Curated Top-5", desc: "Instead of 40 listings, buyers get 5 ranked picks with clear explanations of why each fits." },
+  { icon: MessageCircle, title: "Async Engagement", desc: "Buyers engage on their schedule. AI handles follow-up within brokerage-controlled parameters." },
+  { icon: Brain, title: "Automatic Intent Capture", desc: "No forms. Natural conversation reveals timeline, budget, and preferences automatically." },
+  { icon: Link2, title: "One Link, Zero Threads", desc: "Replace the 10-message email thread with a single shareable link." },
+];
+
+export function SmartResponseSection() {
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            A smarter first response
+          </h2>
+          <p className="text-[#6b7280] text-lg max-w-2xl mx-auto">
+            ResidenceHive transforms how brokerages engage leads from the first touchpoint.
+          </p>
+        </div>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+          {features.map((f) => (
+            <div key={f.title} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7 text-center">
+              <f.icon className="h-8 w-8 text-teal-600 mx-auto mb-4" />
+              <h3 className="font-semibold text-[#111827] mb-2">{f.title}</h3>
+              <p className="text-sm text-[#6b7280]">{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/SocialProofSection.tsx
+++ b/frontend/src/components/landing/SocialProofSection.tsx
@@ -1,56 +1,32 @@
-import { Clock, DollarSign, MapPin, Quote } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
-
-const metrics = [
-  {
-    icon: Clock,
-    value: "~15 min",
-    label: "saved per listing",
-  },
-  {
-    icon: DollarSign,
-    value: "$100+",
-    label: "lead cost protected",
-  },
-  {
-    icon: MapPin,
-    value: "Toronto",
-    label: "pilot market",
-  },
-];
-
 export function SocialProofSection() {
+  const stats = [
+    { number: "2 Markets", label: "Active pilots" },
+    { number: "MLS PIN", label: "& listing data access" },
+    { number: "6-Tier", label: "Compliance framework" },
+  ];
+
   return (
-    <section className="py-16 sm:py-24 bg-white">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Metrics */}
-        <div className="grid sm:grid-cols-3 gap-6 mb-16">
-          {metrics.map((metric, index) => (
-            <Card key={index} className="border-gray-200 text-center">
-              <CardContent className="pt-6">
-                <div className="w-12 h-12 rounded-full bg-teal-50 flex items-center justify-center mx-auto mb-4">
-                  <metric.icon className="h-6 w-6 text-teal-600" />
-                </div>
-                <div className="text-3xl font-bold text-gray-900 mb-1">
-                  {metric.value}
-                </div>
-                <div className="text-gray-600">{metric.label}</div>
-              </CardContent>
-            </Card>
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-[#111827] mb-4">
+            In pilot with Massachusetts and Ontario brokerages
+          </h2>
+        </div>
+        <div className="grid sm:grid-cols-3 gap-6 mb-10">
+          {stats.map((s) => (
+            <div key={s.label} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7 text-center">
+              <div className="text-2xl font-bold text-teal-600 mb-1">{s.number}</div>
+              <div className="text-sm text-[#6b7280]">{s.label}</div>
+            </div>
           ))}
         </div>
-
         {/* Quote */}
-        <div className="max-w-2xl mx-auto">
-          <Card className="border-teal-200 bg-teal-50/50">
-            <CardContent className="pt-6">
-              <Quote className="h-8 w-8 text-teal-400 mb-4" />
-              <blockquote className="text-xl text-gray-700 mb-4 italic">
-                "This saves me ~15 minutes per listing."
-              </blockquote>
-              <p className="text-gray-500">— Agent (demo)</p>
-            </CardContent>
-          </Card>
+        <div className="bg-white border-l-4 border-teal-600 rounded-r-[14px] border border-[#e5e7eb] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7">
+          <p className="text-[#111827] text-lg italic mb-3">
+            "This saves me 15 minutes per listing and catches things I'd miss."
+          </p>
+          <p className="text-[#6b7280] text-sm">— Pilot agent</p>
         </div>
       </div>
     </section>

--- a/frontend/src/components/landing/StepsCard.tsx
+++ b/frontend/src/components/landing/StepsCard.tsx
@@ -1,0 +1,56 @@
+interface Step {
+  number: string;
+  title: string;
+  description: string;
+}
+
+interface StepsCardProps {
+  label: string;
+  subtitle: string;
+  steps: Step[];
+  accentColor?: "teal" | "blue";
+}
+
+const colorMap = {
+  teal: {
+    bar: "bg-teal-600",
+    badge: "text-teal-700 bg-[#f0fdfa] border-[#99f6e8]",
+    number: "text-teal-600",
+  },
+  blue: {
+    bar: "bg-blue-500",
+    badge: "text-blue-700 bg-blue-50 border-blue-200",
+    number: "text-blue-500",
+  },
+};
+
+export function StepsCard({ label, subtitle, steps, accentColor = "teal" }: StepsCardProps) {
+  const colors = colorMap[accentColor];
+
+  return (
+    <div className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] overflow-hidden">
+      <div className={`h-[3px] ${colors.bar}`} />
+      <div className="p-7 sm:p-8">
+        <span className={`inline-block px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider border ${colors.badge} mb-3`}>
+          {label}
+        </span>
+        <p className="text-[#6b7280] text-sm mb-6">{subtitle}</p>
+        <div className="space-y-4">
+          {steps.map((step) => (
+            <div key={step.number} className="flex gap-4">
+              <span className={`font-mono font-bold text-sm ${colors.number} w-6 shrink-0`}>
+                {step.number}
+              </span>
+              <div>
+                <span className="font-semibold text-[#111827]">{step.title}</span>
+                {step.description && (
+                  <span className="text-[#6b7280]"> — {step.description}</span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,11 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
 import { ClerkProvider } from "@clerk/clerk-react";
+import { HelmetProvider } from "react-helmet-async";
 import Landing from "./pages/landing";
+import MassachusettsPage from "./pages/massachusetts";
+import OntarioPage from "./pages/ontario";
+import OfferBotPage from "./pages/offer-bot";
 
 const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 
@@ -11,23 +15,31 @@ if (!clerkPubKey) {
   console.warn("VITE_CLERK_PUBLISHABLE_KEY is not set. Clerk auth will be disabled.");
 }
 
-// Check if we're on the landing page - render it directly without Clerk
-const isLandingPage = window.location.pathname === "/";
+// Public marketing pages — render without Clerk wrapper
+const publicPageMap: Record<string, React.ComponentType> = {
+  "/": Landing,
+  "/massachusetts": MassachusettsPage,
+  "/ontario": OntarioPage,
+  "/offer-bot": OfferBotPage,
+};
+
+const PublicPage = publicPageMap[window.location.pathname];
 
 createRoot(document.getElementById("root")!).render(
-  isLandingPage ? (
-    // Render landing page directly without Clerk wrapper to avoid redirect
-    <Landing />
-  ) : clerkPubKey ? (
-    <ClerkProvider
-      publishableKey={clerkPubKey}
-      signInUrl="/sign-in"
-      signUpUrl="/sign-up"
-      afterSignOutUrl="/"
-    >
+  <HelmetProvider>
+    {PublicPage ? (
+      <PublicPage />
+    ) : clerkPubKey ? (
+      <ClerkProvider
+        publishableKey={clerkPubKey}
+        signInUrl="/sign-in"
+        signUpUrl="/sign-up"
+        afterSignOutUrl="/"
+      >
+        <App />
+      </ClerkProvider>
+    ) : (
       <App />
-    </ClerkProvider>
-  ) : (
-    <App />
-  )
+    )}
+  </HelmetProvider>
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,21 +1,15 @@
 import { createRoot } from "react-dom/client";
-import App from "./App";
 import "./index.css";
-import { ClerkProvider } from "@clerk/clerk-react";
 import { HelmetProvider } from "react-helmet-async";
 import Landing from "./pages/landing";
 import MassachusettsPage from "./pages/massachusetts";
 import OntarioPage from "./pages/ontario";
 import OfferBotPage from "./pages/offer-bot";
 
-const clerkPubKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
-
-if (!clerkPubKey) {
-  // eslint-disable-next-line no-console
-  console.warn("VITE_CLERK_PUBLISHABLE_KEY is not set. Clerk auth will be disabled.");
-}
-
-// Public marketing pages — render without Clerk wrapper
+// Public marketing pages — the first paint for visitors. Rendered directly from
+// the small entry bundle, without Clerk. Everything else (dashboard, analytics,
+// charts, Clerk auth) lives in App and is loaded on demand so these public
+// routes never pay for it.
 const publicPageMap: Record<string, React.ComponentType> = {
   "/": Landing,
   "/massachusetts": MassachusettsPage,
@@ -23,23 +17,21 @@ const publicPageMap: Record<string, React.ComponentType> = {
   "/offer-bot": OfferBotPage,
 };
 
+const root = createRoot(document.getElementById("root")!);
 const PublicPage = publicPageMap[window.location.pathname];
 
-createRoot(document.getElementById("root")!).render(
-  <HelmetProvider>
-    {PublicPage ? (
+if (PublicPage) {
+  root.render(
+    <HelmetProvider>
       <PublicPage />
-    ) : clerkPubKey ? (
-      <ClerkProvider
-        publishableKey={clerkPubKey}
-        signInUrl="/sign-in"
-        signUpUrl="/sign-up"
-        afterSignOutUrl="/"
-      >
-        <App />
-      </ClerkProvider>
-    ) : (
-      <App />
-    )}
-  </HelmetProvider>
-);
+    </HelmetProvider>
+  );
+} else {
+  import("./AppRoot").then(({ default: AppRoot }) => {
+    root.render(
+      <HelmetProvider>
+        <AppRoot />
+      </HelmetProvider>
+    );
+  });
+}

--- a/frontend/src/pages/landing.tsx
+++ b/frontend/src/pages/landing.tsx
@@ -1,20 +1,36 @@
 import { LandingNav } from "@/components/landing/LandingNav";
 import { HeroSection } from "@/components/landing/HeroSection";
+import { NumbersBar } from "@/components/landing/NumbersBar";
 import { ProblemSection } from "@/components/landing/ProblemSection";
-import { SolutionSection } from "@/components/landing/SolutionSection";
+import { SmartResponseSection } from "@/components/landing/SmartResponseSection";
+import { HowItWorksSection } from "@/components/landing/HowItWorksSection";
+import { DemoSection } from "@/components/landing/DemoSection";
+import { ChannelsSection } from "@/components/landing/ChannelsSection";
+import { MarketsSection } from "@/components/landing/MarketsSection";
 import { DifferentiatorsSection } from "@/components/landing/DifferentiatorsSection";
 import { SocialProofSection } from "@/components/landing/SocialProofSection";
 import { CTASection } from "@/components/landing/CTASection";
 import { LandingFooter } from "@/components/landing/LandingFooter";
+import { SEO } from "@/components/SEO";
 
 export default function Landing() {
   return (
     <div className="min-h-screen bg-white">
+      <SEO
+        title="ResidenceHive | AI-Powered Workflows for Real Estate Agents"
+        description="From first lead response to draft-ready offers — built around how agents actually work in each market."
+        canonical="https://residencehive.com/"
+      />
       <LandingNav />
       <main>
         <HeroSection />
+        <NumbersBar />
         <ProblemSection />
-        <SolutionSection />
+        <SmartResponseSection />
+        <HowItWorksSection />
+        <DemoSection />
+        <ChannelsSection />
+        <MarketsSection />
         <DifferentiatorsSection />
         <SocialProofSection />
         <CTASection />

--- a/frontend/src/pages/massachusetts.tsx
+++ b/frontend/src/pages/massachusetts.tsx
@@ -1,0 +1,120 @@
+import { LandingNav } from "@/components/landing/LandingNav";
+import { MarketHero } from "@/components/landing/MarketHero";
+import { MarketCTA } from "@/components/landing/MarketCTA";
+import { LandingFooter } from "@/components/landing/LandingFooter";
+import { SEO } from "@/components/SEO";
+import { Check, Shield, Eye, Building2 } from "lucide-react";
+
+function ProblemStats() {
+  const stats = [
+    "78% of leads never get a personalized response",
+    "The ones that do still get 30+ unranked listings with no context",
+    "By the time an agent follows up, the buyer is already on Zillow's ChatGPT",
+  ];
+  return (
+    <section className="py-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-4 text-center">
+          Massachusetts agents lose leads before they start
+        </h2>
+        <p className="text-[#6b7280] text-lg mb-8 text-center max-w-2xl mx-auto">
+          You pay $100–225+ per lead. Most get a generic listing dump and disappear. The buyer had real intent — budget, timeline, preferences — and none of it was captured.
+        </p>
+        <div className="grid sm:grid-cols-3 gap-6">
+          {stats.map((s) => (
+            <div key={s} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-6 text-center">
+              <p className="text-sm text-[#111827]">{s}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function MAHowItWorks() {
+  const steps = [
+    { n: "1", title: "Lead arrives", desc: "website, Zillow, Realtor.com, referral — any source" },
+    { n: "2", title: "AI builds a buyer profile", desc: "budget, timeline, must-haves, dealbreakers extracted. No forms." },
+    { n: "3", title: "Curated buyer report", desc: "Top 5 listings ranked and explained. Why each one fits. What the trade-offs are. Pulled from MLS PIN data." },
+    { n: "4", title: "Buyer engages on their schedule", desc: "AI chatbot answers questions within brokerage-controlled parameters. Compliance guardrails handle Fair Housing, steering risk, and school data." },
+    { n: "5", title: "Agent gets a qualified lead", desc: "full context: preferences, concerns, engagement history, risk flags. Ready for a real conversation." },
+  ];
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-10 text-center">
+          From lead to qualified buyer — in minutes, not days
+        </h2>
+        <div className="space-y-6">
+          {steps.map((s) => (
+            <div key={s.n} className="flex gap-4">
+              <span className="font-mono font-bold text-teal-600 text-lg w-6 shrink-0">{s.n}</span>
+              <div>
+                <span className="font-semibold text-[#111827]">{s.title}</span>
+                <span className="text-[#6b7280]"> — {s.desc}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComplianceSection() {
+  const features = [
+    { icon: Shield, title: "6-tier compliance framework", desc: "from full comparison (Tier 1) to hard-freeze on demographics (Tier 5) to school data with names and distances but no ratings (Tier 6)" },
+    { icon: Eye, title: "Two-LLM architecture", desc: "one model generates, a second rewrites for compliance. Post-hook rewriters catch what prompts can't." },
+    { icon: Check, title: "Agent-only risk flags", desc: "visual concerns and sensitive topics go to the agent dashboard, not the buyer" },
+    { icon: Building2, title: "Brokerage control", desc: "your brokerage sets the parameters. The AI operates within them." },
+  ];
+  return (
+    <section className="py-20">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-4 text-center">
+          Compliance isn't a feature. It's the architecture.
+        </h2>
+        <p className="text-[#6b7280] text-lg mb-10 text-center max-w-3xl mx-auto">
+          Massachusetts has 14+ Fair Housing protected classes, 254 CMR 3.00, M.G.L. c. 93A, and the NAR August 2024 settlement rules. Generic AI doesn't know any of this. ResidenceHive does.
+        </p>
+        <div className="grid sm:grid-cols-2 gap-6">
+          {features.map((f) => (
+            <div key={f.title} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7">
+              <f.icon className="h-6 w-6 text-teal-600 mb-3" />
+              <h3 className="font-semibold text-[#111827] mb-2">{f.title}</h3>
+              <p className="text-sm text-[#6b7280]">{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function MassachusettsPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <SEO
+        title="AI-Powered Buyer Engagement for Massachusetts Real Estate Agents | ResidenceHive"
+        description="ResidenceHive turns raw leads into qualified buyers — with MLS PIN data, Fair Housing compliance, and agent-controlled AI built for how MA transactions work."
+        canonical="https://residencehive.com/massachusetts"
+      />
+      <LandingNav />
+      <main>
+        <MarketHero
+          headline="AI-powered buyer engagement for Massachusetts agents"
+          subhead="ResidenceHive turns raw leads into qualified buyers — with MLS PIN data, Fair Housing compliance, and agent-controlled AI built for how MA transactions work."
+        />
+        <ProblemStats />
+        <MAHowItWorks />
+        <ComplianceSection />
+        <MarketCTA
+          headline="Join the Massachusetts pilot"
+          subtext="60-day free pilot. MLS PIN data. No long-term contracts."
+        />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/frontend/src/pages/offer-bot.tsx
+++ b/frontend/src/pages/offer-bot.tsx
@@ -1,0 +1,114 @@
+import { LandingNav } from "@/components/landing/LandingNav";
+import { MarketHero } from "@/components/landing/MarketHero";
+import { MarketCTA } from "@/components/landing/MarketCTA";
+import { LandingFooter } from "@/components/landing/LandingFooter";
+import { SEO } from "@/components/SEO";
+import { ArrowRight, Check } from "lucide-react";
+
+function HowOfferBotWorks() {
+  const steps = [
+    { n: "1", title: "Share the deal", desc: "send a listing link or property address, buyer info, and conditions via WhatsApp. Natural language, no forms." },
+    { n: "2", title: "AI extracts and asks", desc: "property details are pulled automatically. Missing fields are flagged — the bot asks for what's incomplete." },
+    { n: "3", title: "Draft forms generated", desc: "market-specific forms pre-filled and ready for review" },
+    { n: "4", title: "Agent reviews and sends", desc: "nothing goes out without agent sign-off" },
+  ];
+  return (
+    <section className="py-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-10 text-center">How Offer Bot works</h2>
+        <div className="space-y-6 mb-8">
+          {steps.map((s) => (
+            <div key={s.n} className="flex gap-4">
+              <span className="font-mono font-bold text-blue-500 text-lg w-6 shrink-0">{s.n}</span>
+              <div>
+                <span className="font-semibold text-[#111827]">{s.title}</span>
+                <span className="text-[#6b7280]"> — {s.desc}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-[#6b7280] italic text-center">
+          Draft preparation, not legal advice. The agent owns every transaction.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function MarketColumns() {
+  const markets = [
+    {
+      title: "Massachusetts",
+      features: [
+        "MLS PIN data integration",
+        "MA Purchase and Sale Agreement",
+        "Local addenda and forms",
+        "Fair Housing compliance guardrails",
+      ],
+      link: "/massachusetts",
+      linkText: "See Massachusetts details",
+    },
+    {
+      title: "Ontario",
+      features: [
+        "Listing-aware autofill from address or listing link",
+        "OREA Form 100 (APS), Form 801, Form 320",
+        "Ontario Human Rights Code compliance",
+        "Multilingual: Urdu, Hindi, Arabic",
+      ],
+      link: "/ontario",
+      linkText: "See Ontario details",
+    },
+  ];
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-10 text-center">Localized for each market</h2>
+        <div className="grid md:grid-cols-2 gap-8">
+          {markets.map((m) => (
+            <div key={m.title} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7 sm:p-8">
+              <h3 className="text-xl font-bold text-[#111827] mb-4">{m.title}</h3>
+              <div className="space-y-2 mb-6">
+                {m.features.map((f) => (
+                  <div key={f} className="flex items-start gap-2">
+                    <Check className="h-4 w-4 text-teal-600 mt-0.5 shrink-0" />
+                    <span className="text-sm text-[#111827]">{f}</span>
+                  </div>
+                ))}
+              </div>
+              <a href={m.link} className="text-teal-600 font-medium text-sm hover:text-teal-700 flex items-center gap-1">
+                {m.linkText} <ArrowRight className="h-4 w-4" />
+              </a>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function OfferBotPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <SEO
+        title="Offer Bot — From Listing Address to Draft-Ready Offer | ResidenceHive"
+        description="Drop a listing link or property address into WhatsApp. ResidenceHive pulls the property details, pre-fills your forms, and delivers a draft package for your review."
+        canonical="https://residencehive.com/offer-bot"
+      />
+      <LandingNav />
+      <main>
+        <MarketHero
+          headline="From listing address to draft-ready offer"
+          subhead="Drop a listing link or property address into WhatsApp. ResidenceHive pulls the property details, pre-fills your forms, and delivers a draft package for your review."
+        />
+        <HowOfferBotWorks />
+        <MarketColumns />
+        <MarketCTA
+          headline="Try Offer Bot in your market"
+          subtext="60-day free pilot. WhatsApp-native. Works with your existing workflow."
+        />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}

--- a/frontend/src/pages/ontario.tsx
+++ b/frontend/src/pages/ontario.tsx
@@ -1,0 +1,138 @@
+import { LandingNav } from "@/components/landing/LandingNav";
+import { MarketHero } from "@/components/landing/MarketHero";
+import { MarketCTA } from "@/components/landing/MarketCTA";
+import { LandingFooter } from "@/components/landing/LandingFooter";
+import { SEO } from "@/components/SEO";
+import { Mic, FileText, Shield, Globe, MessageCircle, Check } from "lucide-react";
+
+function OntarioProblem() {
+  return (
+    <section className="py-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <h2 className="text-3xl font-bold text-[#111827] mb-4">
+          Ontario agents juggle too many manual steps
+        </h2>
+        <p className="text-[#6b7280] text-lg mb-6 max-w-3xl mx-auto">
+          A lead comes in from an open house, a WhatsApp message, a restaurant conversation. The agent has intent — but no system to capture it before it's lost. When the deal moves forward, offer prep is manual: pulling up blank OREA forms, retyping property data, double-checking clause numbers, hoping nothing is missed before the agent reviews.
+        </p>
+        <p className="text-teal-600 font-semibold">Two problems. One platform.</p>
+      </div>
+    </section>
+  );
+}
+
+function BuyerEngagement() {
+  const features = [
+    { icon: Mic, title: "Voice note to buyer profile", desc: "send a 30-second WhatsApp voice note after a conversation, ResidenceHive extracts the buyer's preferences automatically" },
+    { icon: FileText, title: "AI-powered buyer report", desc: "curated listings matched to buyer preferences" },
+    { icon: Shield, title: "Compliant chatbot", desc: "handles buyer questions within Ontario Human Rights Code guardrails" },
+    { icon: Check, title: "Agent approval", desc: "nothing reaches the buyer without the agent's sign-off" },
+  ];
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-4 text-center">Capture leads before they disappear</h2>
+        <p className="text-[#6b7280] text-lg mb-10 text-center max-w-2xl mx-auto">
+          The open house walk-through. The WhatsApp voice note. The referral from a friend. These leads have real intent — but they never make it into your CRM.
+        </p>
+        <div className="grid sm:grid-cols-2 gap-6">
+          {features.map((f) => (
+            <div key={f.title} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7">
+              <f.icon className="h-6 w-6 text-teal-600 mb-3" />
+              <h3 className="font-semibold text-[#111827] mb-2">{f.title}</h3>
+              <p className="text-sm text-[#6b7280]">{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OfferBot() {
+  const steps = [
+    { n: "1", title: "Message your deal", desc: "send a listing link or property address plus buyer info and conditions via WhatsApp. Natural language, no forms." },
+    { n: "2", title: "AI extracts and asks", desc: "system pulls property details (price, beds, baths, lot size, listing info) and flags anything missing" },
+    { n: "3", title: "Draft package generated", desc: "pre-filled OREA forms: Form 100 (Agreement of Purchase and Sale), Form 801, Form 320 (Co-operating Commission)" },
+    { n: "4", title: "Agent reviews", desc: "nothing goes to DocuSign without agent review and approval" },
+  ];
+  return (
+    <section className="py-20">
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-10 text-center">
+          Share the address. We handle the rest.
+        </h2>
+        <div className="space-y-6 mb-8">
+          {steps.map((s) => (
+            <div key={s.n} className="flex gap-4">
+              <span className="font-mono font-bold text-blue-500 text-lg w-6 shrink-0">{s.n}</span>
+              <div>
+                <span className="font-semibold text-[#111827]">{s.title}</span>
+                <span className="text-[#6b7280]"> — {s.desc}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+        <p className="text-sm text-[#6b7280] italic text-center">
+          This is draft preparation, not legal advice. The agent reviews everything. ResidenceHive accelerates the prep — the agent owns the transaction.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function WhyOntario() {
+  const features = [
+    { icon: FileText, title: "OREA forms", desc: "not generic templates. Form 100, Form 801, Form 320, with the right clause structure" },
+    { icon: Check, title: "Listing-aware autofill", desc: "share the address or listing link, we pull the property details and pre-fill your forms" },
+    { icon: Shield, title: "Ontario Human Rights Code compliance", desc: "more protected classes than most US states, built into the AI from day one" },
+    { icon: Globe, title: "Multilingual", desc: "supports Urdu, Hindi, Arabic, and more. 400K+ Urdu speakers in the GTA alone" },
+    { icon: MessageCircle, title: "WhatsApp-native", desc: "because that's how Ontario agents actually communicate with clients" },
+  ];
+  return (
+    <section className="py-20 bg-[#f8faf9]">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 className="text-3xl font-bold text-[#111827] mb-10 text-center">
+          Built for Ontario — not adapted from somewhere else
+        </h2>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {features.map((f) => (
+            <div key={f.title} className="bg-white border border-[#e5e7eb] rounded-[14px] shadow-[0_1px_3px_rgba(0,0,0,0.04)] p-7">
+              <f.icon className="h-6 w-6 text-teal-600 mb-3" />
+              <h3 className="font-semibold text-[#111827] mb-2">{f.title}</h3>
+              <p className="text-sm text-[#6b7280]">{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function OntarioPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <SEO
+        title="AI-Powered Workflows for Ontario Real Estate Agents | ResidenceHive"
+        description="From buyer engagement to draft-ready OREA offer packages — built for how Ontario agents actually work."
+        canonical="https://residencehive.com/ontario"
+      />
+      <LandingNav />
+      <main>
+        <MarketHero
+          headline="AI-powered workflows for Ontario real estate agents"
+          subhead="From buyer engagement to draft-ready OREA offer packages — built for how Ontario agents actually work."
+        />
+        <OntarioProblem />
+        <BuyerEngagement />
+        <OfferBot />
+        <WhyOntario />
+        <MarketCTA
+          headline="Join the Ontario pilot"
+          subtext="60-day free pilot. WhatsApp-native. No long-term contracts."
+        />
+      </main>
+      <LandingFooter />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Brings `main` up to the frontend currently deployed in prod (`residencehive.com`). This branch was deployed ahead of `main`; this PR merges it back. Two things bundled here:

1. **Website restructure** (commits `20e7c22`, `920ac28`, `60854c0`) — new homepage messaging ("Which one would your buyer respond to?"), dual Lead-Engagement + Offer-Prep story, new market pages (`/massachusetts`, `/ontario`) and `/offer-bot`, new nav (Markets ▾ / Offer Bot / How It Works), `SEO` Helmet component, plus mobile-responsive and hero-card fixes.

2. **Landing FOUC fix + code-split + SEO refresh** (commit `d700b1d`) — addresses the "broken/unstyled page on first load" report.

## The FOUC bug

`/` serves an unstyled SEO pre-render into `#root` for crawlers, then React replaces it on mount. Until the ~2 MB JS bundle loaded, users saw the raw unstyled markup (the "broken page" flash); a refresh hit cache so it looked fine. Compounded by the pre-render copy being **stale** (old "first-response layer" text), so the flash showed outdated content too.

### Fixes
- **`server.js`** — inline CSS hides the pre-render's `header/main/footer` until React mounts, so browsers never flash unstyled content. Text crawlers still read the markup.
- **`main.tsx` + `AppRoot.tsx`** — code-split the heavy dashboard/Clerk app out of the entry bundle. Public marketing pages load **~579 kB** instead of **~2.25 MB**; the 1.67 MB `AppRoot` chunk loads only on dashboard/auth routes.
- **`server.js` `LANDING_PAGE_CONTENT` + `index.html` meta** — refreshed the pre-render copy/title to match the live page (Offer Bot, MA/Ontario markets, dual-product story, 60-day-free CTA).

## Verification
- Built clean; public-page payload ~4× smaller.
- Ran the prod server (`node server.js`) locally — `/` renders the correct styled page, no FOUC; pre-render carries current SEO text.
- **Already deployed to prod** (Cloud Run revision `residenthive-frontend-00064-sj4`) and verified live on residencehive.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)